### PR TITLE
Standardize Keycloak JWT resource-server auth, add public/secured endpoints, JSON handlers, docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,7 @@ It's more of a prototype / proof of concept / spring boot playground.  Don't bet
 ## Features and notes
 
 - Gradle build with docker-compose
-- Tried various integrated Spring Boot Security options
-  - BezKoder's JWT auth (Archaic and outdated)
-  - Github and Google OAuth2
-    - Github doesn't really expose an issuer-uri 
-    - and Google's resourceserver provides opaque JWT which require introspection, making it an expensive call to support
-  - Keycloak Auth <- Current target, not quite completed since ran out of time
+- Authentication uses Keycloak + JWT Resource Server validation (see `docs/wiki/auth.md`)
 - Docker compose
   - rabbitmq, for eventual integration of amqp
   - keycloak for the targeted auth system once setup
@@ -27,8 +22,9 @@ It's more of a prototype / proof of concept / spring boot playground.  Don't bet
 
 ## Execution Requirements
 
-- Java 21 or higher
+- Java 21 (recommended for Gradle compatibility in this project)
   - Suggested to install via sdkman (not super stable on Windows)
+  - If your default JVM is newer (e.g. Java 25), set `JAVA_HOME` to Java 21 before running Gradle
 - Docker Desktop
 - Create a `src/main/resources/application-secrets.yml` file with the below contents (replace as necessary)
 
@@ -92,11 +88,13 @@ For production, you don't want to use the included postgres / rabbitMq deploymen
   
 # Authentication
 
-Still a WIP.  It seemed like a worthwhile challenge to focus on
+Authentication is standardized on **Keycloak + JWT Resource Server**.
 
-- Tried BezKoder's JWT (which worked but was severely outdated)
-- OAuth Github and Google but ditched for excessive complexity and heavy limitations
-- Keycloak - still to fully implement but ran out of time
+- Public endpoints: `/api/ping`, `/helloGuest`, and actuator health probes.
+- Secured endpoints: `/helloUser` and `/helloAdmin` with role-based access control.
+- API returns JSON 401/403 responses for auth failures.
+
+See `docs/wiki/auth.md` for details.
 
 # Ordering API
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     // Auth
 //    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
-﻿services:
+services:
   app:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: backend-java-app
     ports:
-      - "8080:8080" # Exposes the application on port 8080
+      - "8080:8080"
     depends_on:
       rabbitmq:
-        condition: service_healthy # takes a while to start
+        condition: service_healthy
       keycloak:
         condition: service_started
     environment:
@@ -16,6 +16,7 @@
       SPRING_RABBITMQ_PORT: 5672
       SPRING_RABBITMQ_USERNAME: guest
       SPRING_RABBITMQ_PASSWORD: guest
+      KEYCLOAK_ISSUER_URI: http://keycloak:8090/realms/myrealm
 
   rabbitmq:
     image: rabbitmq:management
@@ -24,8 +25,8 @@
       RABBITMQ_DEFAULT_USER: guest
       RABBITMQ_DEFAULT_PASS: guest
     ports:
-      - "5672:5672"   # RabbitMQ communication port
-      - "15672:15672" # RabbitMQ management UI port
+      - "5672:5672"
+      - "15672:15672"
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 10s
@@ -45,7 +46,7 @@
       - "8090:8090"
     depends_on:
       - postgres
-    command: start-dev
+    command: start-dev --http-port=8090
 
   postgres:
     image: postgres:latest

--- a/docs/PROTOTYPE_REVIEW.md
+++ b/docs/PROTOTYPE_REVIEW.md
@@ -1,0 +1,75 @@
+# Prototype Review: Scope, Purpose, and Notable Shortcomings
+
+## Overall Scope and Purpose
+
+This codebase is a **Spring Boot prototype** for an order-taking backend that explores three main concerns:
+
+1. **Order API shape and package structure** (`com.backend.order`) for request intake and future orchestration.
+2. **Auth strategy experimentation** (legacy JWT, OAuth2, and current Keycloak-focused resource-server setup).
+3. **Asynchronous messaging integration** via RabbitMQ as a stand-in for eventual fulfillment/event-driven flows.
+
+The project appears intentionally framed as an exploratory playground rather than production-ready software.
+
+## What Exists Today (Prototype Baseline)
+
+- Basic Spring Boot app skeleton and Gradle setup (Java 21, Spring Boot 3.4.x).
+- Starter security wiring with role-based route guards and a custom JWT auth converter.
+- Initial order controller/service/request models with placeholder business logic.
+- RabbitMQ config and test-like message path for verifying queue publish/listen behavior.
+- Docker Compose stack including app + RabbitMQ + Keycloak + Postgres for local experiments.
+- Minimal test scaffolding (`@SpringBootTest` context test only).
+
+## Notable Prototype-Phase Shortcomings
+
+### 1) Domain and persistence are largely stubs
+- `Order` is a plain model with string fields and no persistence annotations/repository.
+- `OrderDao` exists only as an empty placeholder.
+- `getOrderById` returns a new empty object instead of fetching data.
+
+### 2) Controller contract and validation are incomplete
+- `createOrder` accepts request body but does not use `@Valid` despite validation annotations in payloads.
+- Response is a plain success string rather than a structured response with order id/status/errors.
+- Type mismatch risk: controller path variable is `Long`, while model id is `String`.
+
+### 3) Business logic is not implemented yet
+- Service method builds an empty `Order` without mapping request fields.
+- No order lifecycle/status tracking, deduplication/idempotency, or conflict handling.
+- No explicit error model (4xx/5xx mapping, validation problem details, etc.).
+
+### 4) Messaging flow is proof-of-concept only
+- `CountDownLatch` in singleton receiver is not reset safely for repeated/parallel requests.
+- Service waits synchronously on message acknowledgment, which undermines async design.
+- Message payload typing/schema/versioning and dead-letter/retry behavior are not defined.
+
+### 5) Security integration needs hardening and cleanup
+- Security config class contains `@GetMapping` endpoints (mixes configuration and controller concerns).
+- Every route currently requires auth; no explicit public health/info endpoints for ops.
+- Debug/security logging is enabled in config, which is unsafe/noisy for non-dev environments.
+- Token/issuer setup appears split between client/resource-server experiments and may be partially stale.
+
+### 6) Environment and operability gaps
+- Compose/config ports appear inconsistent for Keycloak references vs exposed ports.
+- Secrets strategy is local-file based; no profile-based production secret handling is implemented.
+- Dockerfile assumes pre-built JAR path/name and includes compose file in runtime image unnecessarily.
+
+### 7) Test coverage is near-zero
+- No unit tests for mapping/validation/business rules.
+- No controller tests for request/response and status codes.
+- No integration tests for auth behavior or RabbitMQ publishing path.
+
+### 8) API maturity/documentation gaps
+- No OpenAPI/Swagger contract generated, despite TODO intent.
+- No API versioning strategy, pagination/filtering patterns, or standardized error envelope.
+
+## Prototype-Appropriate Next Priorities
+
+1. Add persistence baseline (JPA entity/repository + migration tooling + seeded local DB).
+2. Complete API contract (`@Valid`, DTO mapping, typed responses, consistent ids, RFC7807 errors).
+3. Separate synchronous order creation from async fulfillment events (outbox or durable publish strategy).
+4. Refactor security boundaries (config vs controller separation; add health/actuator policy).
+5. Introduce practical test pyramid (unit + web slice + integration with Testcontainers).
+6. Publish OpenAPI spec and align request/response/error contracts to it.
+
+## Bottom Line
+
+As a prototype, this repository successfully demonstrates architectural direction and technology evaluation. The main limitation is that most core capabilities (persistence, business rules, robust API contracts, reliable messaging, and test coverage) are still scaffolding-level and need implementation before any production-style usage.

--- a/docs/wiki/auth.md
+++ b/docs/wiki/auth.md
@@ -1,0 +1,49 @@
+# Authentication and Authorization
+
+## Current Standard (Keycloak + JWT Resource Server)
+
+This service uses **Keycloak as the Identity Provider** and validates bearer JWTs with Spring Security's OAuth2 Resource Server support.
+
+### Token validation
+- JWT issuer is configured by `KEYCLOAK_ISSUER_URI`.
+- Default local issuer: `http://localhost:8090/realms/myrealm`.
+- In docker-compose, app uses `http://keycloak:8090/realms/myrealm`.
+
+### Authorization model
+- Role-based access control (RBAC) is enforced from JWT claims.
+- Roles are extracted from:
+  - `realm_access.roles`
+  - `resource_access.demo.roles`
+- Roles are normalized to Spring authorities (`ROLE_*`).
+
+### Endpoint access policy
+Public (no auth required):
+- `GET /api/ping`
+- `GET /helloGuest`
+- `GET /actuator/health`
+- `GET /actuator/health/liveness`
+- `GET /actuator/health/readiness`
+
+Protected:
+- `GET /helloUser` requires `ROLE_USER` or `ROLE_ADMIN`
+- `GET /helloAdmin` requires `ROLE_ADMIN`
+- everything else requires authentication
+
+### Error handling
+Security failures return JSON responses:
+- **401 Unauthorized** when token is missing/invalid
+- **403 Forbidden** when token is valid but lacks required role
+
+## Health and readiness
+The service exposes Actuator health probes:
+- Liveness: `/actuator/health/liveness`
+- Readiness: `/actuator/health/readiness`
+
+This is the production-standard baseline and should be preferred over custom-only health routes.
+
+## Brief historical notes
+- **Custom/legacy JWT approach**: dropped due to maintainability and modernization concerns.
+- **GitHub OAuth attempt**: not suitable as a clean issuer-based resource-server fit for this API model.
+- **Google OAuth attempt**: introduced complexity and API-calling overhead for token handling in this backend context.
+
+The project now standardizes on Keycloak + JWT resource-server validation.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,2 +1,23 @@
-#!/bin/bash
-./gradlew clean build
+#!/usr/bin/env bash
+set -euo pipefail
+
+use_java21_if_available() {
+  for candidate in \
+    "$HOME/.local/share/mise/installs/java/21.0.2" \
+    "$HOME/.local/share/mise/installs/java/21"; do
+    if [[ -x "$candidate/bin/java" ]]; then
+      export JAVA_HOME="$candidate"
+      export PATH="$JAVA_HOME/bin:$PATH"
+      return 0
+    fi
+  done
+  return 1
+}
+
+current_java_version="$(java -version 2>&1 | head -n1 || true)"
+if [[ "$current_java_version" != *'"21.'* ]] && [[ "$current_java_version" != *'"21"'* ]]; then
+  use_java21_if_available || true
+fi
+
+java -version
+./gradlew clean build --no-daemon

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,2 +1,23 @@
-#!/bin/bash
-./gradlew test
+#!/usr/bin/env bash
+set -euo pipefail
+
+use_java21_if_available() {
+  for candidate in \
+    "$HOME/.local/share/mise/installs/java/21.0.2" \
+    "$HOME/.local/share/mise/installs/java/21"; do
+    if [[ -x "$candidate/bin/java" ]]; then
+      export JAVA_HOME="$candidate"
+      export PATH="$JAVA_HOME/bin:$PATH"
+      return 0
+    fi
+  done
+  return 1
+}
+
+current_java_version="$(java -version 2>&1 | head -n1 || true)"
+if [[ "$current_java_version" != *'"21.'* ]] && [[ "$current_java_version" != *'"21"'* ]]; then
+  use_java21_if_available || true
+fi
+
+java -version
+./gradlew test --no-daemon

--- a/src/main/java/com/backend/controllers/PublicController.java
+++ b/src/main/java/com/backend/controllers/PublicController.java
@@ -1,0 +1,21 @@
+package com.backend.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class PublicController {
+
+    @GetMapping("/api/ping")
+    public ResponseEntity<Map<String, String>> ping() {
+        return ResponseEntity.ok(Map.of("status", "ok"));
+    }
+
+    @GetMapping("/helloGuest")
+    public ResponseEntity<Map<String, String>> helloGuest() {
+        return ResponseEntity.ok(Map.of("message", "helloGuest"));
+    }
+}

--- a/src/main/java/com/backend/controllers/SecuredHelloController.java
+++ b/src/main/java/com/backend/controllers/SecuredHelloController.java
@@ -1,0 +1,21 @@
+package com.backend.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class SecuredHelloController {
+
+    @GetMapping("/helloUser")
+    public ResponseEntity<Map<String, String>> helloUser() {
+        return ResponseEntity.ok(Map.of("message", "helloUser"));
+    }
+
+    @GetMapping("/helloAdmin")
+    public ResponseEntity<Map<String, String>> helloAdmin() {
+        return ResponseEntity.ok(Map.of("message", "helloAdmin"));
+    }
+}

--- a/src/main/java/com/backend/security/JsonAccessDeniedHandler.java
+++ b/src/main/java/com/backend/security/JsonAccessDeniedHandler.java
@@ -1,0 +1,41 @@
+package com.backend.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+
+@Component
+public class JsonAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public JsonAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        objectMapper.writeValue(response.getOutputStream(), Map.of(
+                "timestamp", Instant.now().toString(),
+                "status", HttpServletResponse.SC_FORBIDDEN,
+                "error", "Forbidden",
+                "message", "You do not have permission to access this resource",
+                "path", request.getRequestURI()
+        ));
+    }
+}

--- a/src/main/java/com/backend/security/JsonAuthenticationEntryPoint.java
+++ b/src/main/java/com/backend/security/JsonAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.backend.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+
+@Component
+public class JsonAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public JsonAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        objectMapper.writeValue(response.getOutputStream(), Map.of(
+                "timestamp", Instant.now().toString(),
+                "status", HttpServletResponse.SC_UNAUTHORIZED,
+                "error", "Unauthorized",
+                "message", "Authentication is required to access this resource",
+                "path", request.getRequestURI()
+        ));
+    }
+}

--- a/src/main/java/com/backend/security/JwtAuthConverter.java
+++ b/src/main/java/com/backend/security/JwtAuthConverter.java
@@ -48,9 +48,6 @@ public class JwtAuthConverter implements Converter<Jwt, AbstractAuthenticationTo
             }
         }
 
-        // Debugging extracted roles
-        System.out.println("Extracted roles: " + roles);
-
         return roles.stream()
                 .map(role -> new SimpleGrantedAuthority("ROLE_" + role.toUpperCase()))
                 .collect(Collectors.toSet());

--- a/src/main/java/com/backend/security/SecurityConfig.java
+++ b/src/main/java/com/backend/security/SecurityConfig.java
@@ -2,50 +2,48 @@ package com.backend.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.bind.annotation.GetMapping;
 
-/**
- * See <a href="https://github.com/av24soft/keycloak/blob/main/Keyclockdemo">av24soft Keycloak Demo</a> for more info
- */
 @Configuration
 public class SecurityConfig {
 
-    final JwtAuthConverter authConverter;
+    private final JwtAuthConverter authConverter;
+    private final JsonAuthenticationEntryPoint authenticationEntryPoint;
+    private final JsonAccessDeniedHandler accessDeniedHandler;
 
-    public SecurityConfig(JwtAuthConverter authConverter) {
+    public SecurityConfig(
+            JwtAuthConverter authConverter,
+            JsonAuthenticationEntryPoint authenticationEntryPoint,
+            JsonAccessDeniedHandler accessDeniedHandler
+    ) {
         this.authConverter = authConverter;
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
     }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(HttpMethod.GET, "/api/ping", "/helloGuest").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
                         .requestMatchers("/helloAdmin").hasRole("ADMIN")
-                        .requestMatchers("/helloUser").hasRole("USER")
+                        .requestMatchers("/helloUser").hasAnyRole("USER", "ADMIN")
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                )
                 .oauth2ResourceServer(oauth2 -> oauth2
-                        .jwt(jwt -> jwt
-                                .jwtAuthenticationConverter(authConverter)
-                        )
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(authConverter))
                 );
 
         return http.build();
-    }
-
-    @GetMapping("/helloUser")
-    public String helloUser()
-    {
-
-        return "helloUser";
-    }
-
-    @GetMapping("/helloAdmin")
-    public String helloAdmin()
-    {
-
-        return "helloAdmin";
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,17 +5,9 @@ spring:
     name: order-taking-api
   security:
     oauth2:
-      client:
-        registration:
-          keycloak:
-            client-id: demo
-            scope: openid
-        provider:
-          keycloak:
-            issuer-uri: http://localhost:8080/realms/myrealm
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8080/realms/myrealm
+          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:8090/realms/myrealm}
 
   rabbitmq:
     host: localhost
@@ -23,9 +15,21 @@ spring:
     username: ${secret.rabbitmq.username}
     password: ${secret.rabbitmq.password}
 
-  mvc:
-    # Development only
-    log-request-details: true
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: never
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
 
 # Logging
 logging:
@@ -33,7 +37,6 @@ logging:
     root: info
     org:
       springframework:
-        security: debug
-        security.oauth2.client: debug
-        web: debug
+        security: info
+        web: info
         boot: info

--- a/src/test/java/com/backend/integration/SecurityIntegrationTest.java
+++ b/src/test/java/com/backend/integration/SecurityIntegrationTest.java
@@ -1,0 +1,48 @@
+package com.backend.integration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void allowsPublicEndpointsWithoutAuthentication() throws Exception {
+        mockMvc.perform(get("/api/ping")).andExpect(status().isOk());
+        mockMvc.perform(get("/helloGuest")).andExpect(status().isOk());
+        mockMvc.perform(get("/actuator/health/readiness")).andExpect(status().isOk());
+    }
+
+    @Test
+    void rejectsProtectedEndpointWithoutAuthentication() throws Exception {
+        mockMvc.perform(get("/helloUser")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void allowsHelloUserForUserRoleToken() throws Exception {
+        mockMvc.perform(get("/helloUser").with(jwt().authorities(() -> "ROLE_USER")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void rejectsHelloAdminForNonAdminRoleToken() throws Exception {
+        mockMvc.perform(get("/helloAdmin").with(jwt().authorities(() -> "ROLE_USER")))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/backend/security/JwtAuthConverterTest.java
+++ b/src/test/java/com/backend/security/JwtAuthConverterTest.java
@@ -1,0 +1,35 @@
+package com.backend.security;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtAuthConverterTest {
+
+    private final JwtAuthConverter converter = new JwtAuthConverter();
+
+    @ParameterizedTest
+    @CsvSource({
+            "user,ROLE_USER",
+            "admin,ROLE_ADMIN",
+            "support,ROLE_SUPPORT"
+    })
+    void convertsRealmRolesToSpringAuthorities(String sourceRole, String expectedAuthority) {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .claim("realm_access", Map.of("roles", List.of(sourceRole)))
+                .build();
+
+        Authentication authentication = converter.convert(jwt);
+
+        assertThat(authentication.getAuthorities())
+                .extracting("authority")
+                .contains(expectedAuthority);
+    }
+}


### PR DESCRIPTION
### Motivation

- Standardize authentication on Keycloak + JWT resource-server and provide clear, role-based endpoint protection and JSON error responses.
- Make local development and composition more predictable by fixing Keycloak ports/issuer wiring and exposing health probes via Actuator.
- Improve developer ergonomics by adding small helper scripts that prefer Java 21 and a short prototype review and auth docs. 

### Description

- Added Keycloak-focused security stack with `SecurityConfig`, a `JwtAuthConverter`, and JSON error handlers `JsonAuthenticationEntryPoint` and `JsonAccessDeniedHandler` to return structured 401/403 responses. 
- Introduced public and secured endpoints via `PublicController` (`/api/ping`, `/helloGuest`) and `SecuredHelloController` (`/helloUser`, `/helloAdmin`) and exposed Actuator health/readiness endpoints. 
- Updated configuration and compose wiring to use a configurable issuer URI (`KEYCLOAK_ISSUER_URI`) and adjusted Keycloak startup port in `docker-compose.yml` and `application.yml`, plus added `spring-boot-actuator` dependency and management settings. 
- Added documentation and review artifacts: `docs/wiki/auth.md` describing auth behavior and `docs/PROTOTYPE_REVIEW.md`, updated `README.md` to reflect Keycloak usage, and added robust `build.sh` and `test.sh` scripts that prefer Java 21. 

### Testing

- Added and ran unit tests for JWT conversion (`JwtAuthConverterTest`) which assert realm role extraction to Spring authorities and they passed. 
- Added and ran integration tests (`SecurityIntegrationTest`) using `@SpringBootTest`+`MockMvc` to verify public endpoints, protected routes, and role-based access and they passed. 
- Ran the automated test command via `./scripts/test.sh` (which runs `./gradlew test --no-daemon`) and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83600441c8326ae1b36c7e2a60d26)