### PR TITLE
Add OpenAPI contract-first generation, Swagger UI and retain JWT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,15 @@ Also a WIP.  Placed some skeleton structure.
 - Best to evolve the code alongside the necessary demands.
 - Generally speaking however, API work is quite straightforward and "boring"
 - Would absolutely use an Open API Spec 3.0 for documenting (even if just for internal use only)
+
+# OpenAPI and endpoint generation
+
+The project now uses an **OpenAPI 3 contract-first workflow** for endpoint documentation and server stub generation.
+
+- Contract file: `src/main/resources/openapi/order-taking-api.yaml`
+- Generate Spring interfaces/models: `./scripts/openapi-generate.sh`
+- Validate OpenAPI contract: `./scripts/openapi-validate.sh`
+- Swagger UI (when app is running): `/swagger-ui/index.html`
+- Raw OpenAPI docs endpoint: `/v3/api-docs`
+
+Security scheme in the OpenAPI contract is configured as JWT Bearer and aligned with the existing resource server setup.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,10 @@
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
+
 plugins {
     java
     id("org.springframework.boot") version "3.4.4"
     id("io.spring.dependency-management") version "1.1.7"
+    id("org.openapi.generator") version "7.14.0"
 }
 
 group = "com.backend"
@@ -17,12 +20,22 @@ repositories {
     mavenCentral()
 }
 
+val generatedOpenApiDir = layout.buildDirectory.dir("generated/openapi")
+
+sourceSets {
+    named("main") {
+        java.srcDir(generatedOpenApiDir.map { it.dir("src/main/java") })
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
-    // Auth
-//    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+
+    // API documentation
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
+    implementation("io.swagger.core.v3:swagger-annotations-jakarta:2.2.30")
 
     // Data
     implementation("org.springframework.boot:spring-boot-starter-validation")
@@ -31,6 +44,29 @@ dependencies {
     // Testing
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
+}
+
+tasks.register<GenerateTask>("generateOpenApiServer") {
+    generatorName.set("spring")
+    inputSpec.set("$projectDir/src/main/resources/openapi/order-taking-api.yaml")
+    outputDir.set(generatedOpenApiDir.get().asFile.absolutePath)
+    apiPackage.set("com.backend.openapi.api")
+    modelPackage.set("com.backend.openapi.model")
+    configOptions.set(
+        mapOf(
+            "interfaceOnly" to "true",
+            "useSpringBoot3" to "true",
+            "useJakartaEe" to "true",
+            "documentationProvider" to "springdoc",
+            "openApiNullable" to "false",
+            "performBeanValidation" to "true",
+            "useTags" to "true"
+        )
+    )
+}
+
+tasks.withType<JavaCompile> {
+    dependsOn(tasks.named("generateOpenApiServer"))
 }
 
 tasks.withType<Test> {

--- a/scripts/openapi-generate.sh
+++ b/scripts/openapi-generate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+use_java21_if_available() {
+  for candidate in     "$HOME/.local/share/mise/installs/java/21.0.2"     "$HOME/.local/share/mise/installs/java/21"; do
+    if [[ -x "$candidate/bin/java" ]]; then
+      export JAVA_HOME="$candidate"
+      export PATH="$JAVA_HOME/bin:$PATH"
+      return 0
+    fi
+  done
+  return 1
+}
+
+current_java_version="$(java -version 2>&1 | head -n1 || true)"
+if [[ "$current_java_version" != *'"21.'* ]] && [[ "$current_java_version" != *'"21"'* ]]; then
+  use_java21_if_available || true
+fi
+
+java -version
+./gradlew generateOpenApiServer --no-daemon

--- a/scripts/openapi-validate.sh
+++ b/scripts/openapi-validate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+use_java21_if_available() {
+  for candidate in     "$HOME/.local/share/mise/installs/java/21.0.2"     "$HOME/.local/share/mise/installs/java/21"; do
+    if [[ -x "$candidate/bin/java" ]]; then
+      export JAVA_HOME="$candidate"
+      export PATH="$JAVA_HOME/bin:$PATH"
+      return 0
+    fi
+  done
+  return 1
+}
+
+current_java_version="$(java -version 2>&1 | head -n1 || true)"
+if [[ "$current_java_version" != *'"21.'* ]] && [[ "$current_java_version" != *'"21"'* ]]; then
+  use_java21_if_available || true
+fi
+
+java -version
+./gradlew openApiValidate --no-daemon

--- a/src/main/java/com/backend/security/SecurityConfig.java
+++ b/src/main/java/com/backend/security/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.GET, "/api/ping", "/helloGuest").permitAll()
                         .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/helloAdmin").hasRole("ADMIN")
                         .requestMatchers("/helloUser").hasAnyRole("USER", "ADMIN")
                         .anyRequest().authenticated()

--- a/src/main/resources/openapi/order-taking-api.yaml
+++ b/src/main/resources/openapi/order-taking-api.yaml
@@ -1,0 +1,229 @@
+openapi: 3.0.3
+info:
+  title: Order Taking API
+  version: 1.0.0
+  description: API contract for order taking endpoints and auth demo endpoints.
+servers:
+  - url: /
+security:
+  - bearerAuth: []
+
+tags:
+  - name: Public
+  - name: Greeting
+  - name: Orders
+
+paths:
+  /api/ping:
+    get:
+      operationId: ping
+      tags: [Public]
+      security: []
+      summary: Public health ping
+      responses:
+        '200':
+          description: Service is available
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+
+  /helloGuest:
+    get:
+      operationId: helloGuest
+      tags: [Public]
+      security: []
+      summary: Public hello endpoint
+      responses:
+        '200':
+          description: Public greeting
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+
+  /helloUser:
+    get:
+      operationId: helloUser
+      tags: [Greeting]
+      summary: Greeting for USER and ADMIN roles
+      responses:
+        '200':
+          description: Authenticated greeting
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+        '401':
+          description: Missing/invalid JWT
+        '403':
+          description: Insufficient role
+
+  /helloAdmin:
+    get:
+      operationId: helloAdmin
+      tags: [Greeting]
+      summary: Greeting for ADMIN role
+      responses:
+        '200':
+          description: Admin greeting
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+        '401':
+          description: Missing/invalid JWT
+        '403':
+          description: Insufficient role
+
+  /api/orders:
+    post:
+      operationId: createOrder
+      tags: [Orders]
+      summary: Create a new order
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateOrderRequest'
+      responses:
+        '200':
+          description: Order created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateOrderResponse'
+        '401':
+          description: Missing/invalid JWT
+
+  /api/orders/{orderId}:
+    get:
+      operationId: getOrder
+      tags: [Orders]
+      summary: Get an existing order by id
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Order found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '401':
+          description: Missing/invalid JWT
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    StatusResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          example: ok
+
+    MessageResponse:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+
+    CreateOrderRequest:
+      type: object
+      required: [customerDetails, installationDetails, products]
+      properties:
+        customerDetails:
+          $ref: '#/components/schemas/CustomerDetails'
+        installationDetails:
+          $ref: '#/components/schemas/InstallationDetails'
+        products:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/ProductDetails'
+
+    CustomerDetails:
+      type: object
+      required: [name, phone]
+      properties:
+        name:
+          type: string
+        phone:
+          type: string
+          pattern: '^\\d{8}$'
+
+    InstallationDetails:
+      type: object
+      required: [address, preferredDateTime, timeSlot]
+      properties:
+        address:
+          type: string
+        preferredDateTime:
+          type: string
+          format: date-time
+        timeSlot:
+          type: string
+
+    ProductDetails:
+      type: object
+      required: [productType, packageType]
+      properties:
+        productType:
+          $ref: '#/components/schemas/ProductType'
+        packageType:
+          $ref: '#/components/schemas/PackageType'
+
+    ProductType:
+      type: string
+      enum: [INTERNET, TV, TELEPHONY, MOBILE]
+
+    PackageType:
+      type: string
+      enum:
+        - INTERNET_250_MBPS
+        - INTERNET_1_GBPS
+        - TV_90_CHANNELS
+        - TV_140_CHANNELS
+        - FREE_ON_NET_CALLS
+        - UNLIMITED_CALLS
+        - MOBILE_PREPAID
+        - MOBILE_POSTPAID
+
+    CreateOrderResponse:
+      type: object
+      required: [orderDetails]
+      properties:
+        orderDetails:
+          $ref: '#/components/schemas/Order'
+
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        customerDetails:
+          type: string
+        installationAddress:
+          type: string
+        preferredInstallationDate:
+          type: string
+        timeSlotDetails:
+          type: string
+        requiredProducts:
+          type: string
+        requiredPackage:
+          type: string

--- a/src/test/java/com/backend/integration/SecurityIntegrationTest.java
+++ b/src/test/java/com/backend/integration/SecurityIntegrationTest.java
@@ -27,6 +27,8 @@ class SecurityIntegrationTest {
         mockMvc.perform(get("/api/ping")).andExpect(status().isOk());
         mockMvc.perform(get("/helloGuest")).andExpect(status().isOk());
         mockMvc.perform(get("/actuator/health/readiness")).andExpect(status().isOk());
+        mockMvc.perform(get("/v3/api-docs")).andExpect(status().isOk());
+        mockMvc.perform(get("/swagger-ui/index.html")).andExpect(status().isOk());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- Provide an OpenAPI 3 contract-first workflow so API surface is documented and Spring server interfaces/models can be generated automatically. 
- Keep existing JWT Resource Server protection and ensure docs endpoints can be exposed for developer ergonomics. 

### Description

- Added OpenAPI Generator Gradle plugin and configured a `generateOpenApiServer` task to produce Spring (Spring Boot 3 / Jakarta) interfaces and models during the build by reading `src/main/resources/openapi/order-taking-api.yaml`. 
- Wired generated sources into the `main` source set and added Springdoc (`springdoc-openapi-starter-webmvc-ui`) and Swagger annotations to provide a Swagger UI and `v3/api-docs` output. 
- Added a contract at `src/main/resources/openapi/order-taking-api.yaml` that documents public, secured greeting endpoints and order endpoints, including a JWT `bearerAuth` security scheme and request/response schemas. 
- Added helper scripts `scripts/openapi-generate.sh` and `scripts/openapi-validate.sh` to run generation/validation with a Java 21 auto-selection fallback. 
- Updated `SecurityConfig` to permit OpenAPI/docs endpoints (`/v3/api-docs/**`, `/swagger-ui/**`, `/swagger-ui.html`) while preserving JWT-based access rules for app endpoints. 
- Extended integration test `SecurityIntegrationTest` to assert that docs endpoints are publicly accessible. 
- Documented the workflow and endpoints in `README.md` and added the generation/validation scripts to the repo. 

### Testing

- Attempted to run generation with `./gradlew generateOpenApiServer` and run tests with `./scripts/test.sh`, but the build failed in this environment due to the Gradle plugin resolution error (`org.springframework.boot` plugin could not be resolved from the plugin repository). 
- Also reproduced the Java-version guard and re-ran generation with a Java 21 toolchain selection (the scripts include Java 21 auto-selection), but plugin resolution failure still prevented full generation and test execution. 
- Integration tests were updated to cover docs endpoints, but automated test execution did not complete successfully here because of the plugin resolution failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8420beee08326990be203e9daf154)