### PR TITLE
Introducing game support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This repository stays intentionally small and favors platform basics over premat
 - PR-based CI validation
 - stateless OAuth2 resource-server security with Keycloak
 - PostgreSQL persistence with Flyway migrations and Spring JDBC
+- first local-dev gameplay session + authoritative movement slice
 - role-based access control backed by JWT claims
 - local operability with a minimal auth stack
 - health probes and JSON auth failure responses
@@ -71,10 +72,14 @@ Implemented today:
 - Maven wrapper build and PR workflow validation
 - published OpenAPI contract via `/v3/api-docs` and Swagger UI
 - PostgreSQL wiring with SQL migrations and a `JdbcClient` repository baseline
+- authenticated gameplay session issuance for a local realtime boundary
+- in-memory authoritative player movement over raw WebSocket
+- coarse durable player location persistence for reconnect/recovery
 
 Not yet implemented:
-- game-domain modules
-- realtime transport systems
+- combat, inventory, matchmaking, or broader game-domain modules
+- replication beyond the moving player's own authoritative state
+- dedicated realtime service or UDP transport
 - deployment automation
 
 ## Running the Project
@@ -119,6 +124,7 @@ Public endpoints:
 Role-protected endpoints:
 - `GET /api/access/user`
 - `GET /api/access/admin`
+- `POST /api/gameplay/sessions`
 
 Contract endpoints:
 - `GET /v3/api-docs`
@@ -128,6 +134,7 @@ Contract endpoints:
 
 - [docs/wiki/auth.md](docs/wiki/auth.md): application security contract
 - [docs/wiki/auth-keycloak.md](docs/wiki/auth-keycloak.md): local Keycloak flow
+- [docs/wiki/movement.md](docs/wiki/movement.md): first authoritative movement slice
 - [docs/plan.md](docs/plan.md): delivery roadmap
 - [docs/TODO.md](docs/TODO.md): implementation backlog
 - [docs/CHANGELIST.md](docs/CHANGELIST.md): engineering milestones

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,6 +14,7 @@
 
 ## Realtime
 - WebSocket gameplay transport
+- Broaden movement slice beyond self-only reconciliation
 - Evaluate TLS 1.3 / QUIC for low-latency flows
 - Split realtime systems into isolated modules
 - Runtime redis capability

--- a/docs/wiki/movement.md
+++ b/docs/wiki/movement.md
@@ -1,0 +1,95 @@
+# Movement Slice
+
+## Goal
+
+Introduce the first minimal realtime gameplay slice without changing the repository's role as a Spring Boot control plane.
+
+Current scope:
+- authenticated gameplay session issuance over HTTP
+- local in-memory authoritative movement runtime
+- raw WebSocket transport for movement intent only
+- coarse durable player location persistence for reconnect and logout recovery
+
+Out of scope for this slice:
+- combat, inventory, replication beyond self-state, matchmaking
+- UDP, Redis, multi-node coordination, distributed interest management
+- per-frame database writes
+
+## Control Plane Vs Realtime Boundary
+
+Control plane responsibilities in this repository:
+- validate bearer tokens with the existing Keycloak-backed resource server
+- issue short-lived gameplay session tokens from authenticated HTTP requests
+- bootstrap player identity and recover last durable coarse location
+- persist coarse location when a gameplay session is closed or disconnected
+
+Realtime boundary responsibilities in this slice:
+- accept movement intent over WebSocket
+- maintain active movement state in memory
+- compute authoritative position on the server
+- emit authoritative position snapshots back to the same client
+
+The transport layer is intentionally thin. WebSocket code validates session access and forwards parsed intent into gameplay services, but it does not own movement rules.
+
+## Authoritative Intent Model
+
+The client sends intent, not absolute position:
+- session id is implicit in the WebSocket connection
+- each message carries an input timestamp and one 8-direction movement intent
+- the server advances from its last authoritative state using elapsed server time and configured movement speed
+- the server accepts only the latest input timestamp for a session and ignores older intent updates
+
+Why not send absolute position:
+- client positions are easy to spoof
+- server-side integration gives one source of truth for reconciliation
+- later physics, collision, stamina, or map constraints can hook into the same authority layer without changing the transport contract
+
+Current movement model shortcuts:
+- timestamp-driven simulation instead of a dedicated fixed tick loop
+- one active session per player inside a single JVM
+- only the moving player receives authoritative state updates
+
+## Persistence Strategy
+
+Persisted durably:
+- `player_profile.external_subject` as the current auth-to-player bridge
+- `player_location` with `player_id`, `zone_id`, `position_x`, `position_y`, and `updated_at`
+
+Kept in memory only:
+- issued gameplay session tokens
+- active authoritative movement state
+- active WebSocket connection attachment
+
+Persistence boundaries for this slice:
+- gameplay session replacement for the same player
+- WebSocket disconnect or transport error
+
+Not persisted on every update:
+- movement intent messages
+- intermediate authoritative movement frames
+
+This keeps PostgreSQL on the control-plane side of the design and avoids turning movement into a write-amplified hot path.
+
+## Local Flow
+
+1. Client calls `POST /api/gameplay/sessions` with a normal bearer token.
+2. Server resolves or creates a local player profile and loads the last durable coarse location.
+3. Server returns a short-lived session id, session token, WebSocket path, and initial authoritative state.
+4. Client connects to `/ws/gameplay?sessionId=...&token=...`.
+5. Client sends movement intent messages like:
+
+```json
+{"inputTime":"2026-04-11T08:00:00Z","direction":"NORTH_EAST"}
+```
+
+6. Server replies with authoritative position snapshots for reconciliation.
+7. On disconnect, the latest coarse location is persisted.
+
+## Replace Later
+
+Expected replacement points as the realtime stack grows:
+- raw WebSocket handshake/session-token flow can move behind a dedicated gateway or realtime service
+- in-memory session and movement stores can move to dedicated process state management
+- timestamp-driven movement integration can become a fixed-step simulation loop
+- self-only outbound updates can evolve into area-of-interest replication
+- coarse persistence on disconnect can become explicit checkpoints or handoff events

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>

--- a/src/main/java/com/backend/gameplay/config/GameplayConfig.java
+++ b/src/main/java/com/backend/gameplay/config/GameplayConfig.java
@@ -1,0 +1,22 @@
+package com.backend.gameplay.config;
+
+import com.backend.gameplay.movement.GameplayMovementProperties;
+import com.backend.gameplay.session.GameplaySessionProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+@EnableConfigurationProperties({
+        GameplaySessionProperties.class,
+        GameplayMovementProperties.class
+})
+public class GameplayConfig {
+
+    @Bean
+    public Clock systemClock() {
+        return Clock.systemUTC();
+    }
+}

--- a/src/main/java/com/backend/gameplay/movement/ActiveMovementState.java
+++ b/src/main/java/com/backend/gameplay/movement/ActiveMovementState.java
@@ -1,0 +1,88 @@
+package com.backend.gameplay.movement;
+
+import java.time.Instant;
+import java.util.UUID;
+
+final class ActiveMovementState {
+
+    private final UUID sessionId;
+    private final UUID playerId;
+    private final String zoneId;
+    private double positionX;
+    private double positionY;
+    private MovementDirection direction;
+    private Instant lastSimulatedAt;
+    private Instant lastAcceptedInputTime;
+
+    ActiveMovementState(
+            UUID sessionId,
+            UUID playerId,
+            String zoneId,
+            double positionX,
+            double positionY,
+            MovementDirection direction,
+            Instant lastSimulatedAt,
+            Instant lastAcceptedInputTime
+    ) {
+        this.sessionId = sessionId;
+        this.playerId = playerId;
+        this.zoneId = zoneId;
+        this.positionX = positionX;
+        this.positionY = positionY;
+        this.direction = direction;
+        this.lastSimulatedAt = lastSimulatedAt;
+        this.lastAcceptedInputTime = lastAcceptedInputTime;
+    }
+
+    UUID sessionId() {
+        return sessionId;
+    }
+
+    UUID playerId() {
+        return playerId;
+    }
+
+    String zoneId() {
+        return zoneId;
+    }
+
+    double positionX() {
+        return positionX;
+    }
+
+    void setPositionX(double positionX) {
+        this.positionX = positionX;
+    }
+
+    double positionY() {
+        return positionY;
+    }
+
+    void setPositionY(double positionY) {
+        this.positionY = positionY;
+    }
+
+    MovementDirection direction() {
+        return direction;
+    }
+
+    void setDirection(MovementDirection direction) {
+        this.direction = direction;
+    }
+
+    Instant lastSimulatedAt() {
+        return lastSimulatedAt;
+    }
+
+    void setLastSimulatedAt(Instant lastSimulatedAt) {
+        this.lastSimulatedAt = lastSimulatedAt;
+    }
+
+    Instant lastAcceptedInputTime() {
+        return lastAcceptedInputTime;
+    }
+
+    void setLastAcceptedInputTime(Instant lastAcceptedInputTime) {
+        this.lastAcceptedInputTime = lastAcceptedInputTime;
+    }
+}

--- a/src/main/java/com/backend/gameplay/movement/AuthoritativeMovementState.java
+++ b/src/main/java/com/backend/gameplay/movement/AuthoritativeMovementState.java
@@ -1,0 +1,16 @@
+package com.backend.gameplay.movement;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record AuthoritativeMovementState(
+        UUID sessionId,
+        UUID playerId,
+        String zoneId,
+        double positionX,
+        double positionY,
+        MovementDirection direction,
+        Instant serverTime,
+        Instant lastAcceptedInputTime
+) {
+}

--- a/src/main/java/com/backend/gameplay/movement/GameplayMovementProperties.java
+++ b/src/main/java/com/backend/gameplay/movement/GameplayMovementProperties.java
@@ -1,0 +1,26 @@
+package com.backend.gameplay.movement;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.gameplay.movement")
+public class GameplayMovementProperties {
+
+    private double speedUnitsPerSecond = 4.0;
+    private String defaultZoneId = "starter-zone";
+
+    public double getSpeedUnitsPerSecond() {
+        return speedUnitsPerSecond;
+    }
+
+    public void setSpeedUnitsPerSecond(double speedUnitsPerSecond) {
+        this.speedUnitsPerSecond = speedUnitsPerSecond;
+    }
+
+    public String getDefaultZoneId() {
+        return defaultZoneId;
+    }
+
+    public void setDefaultZoneId(String defaultZoneId) {
+        this.defaultZoneId = defaultZoneId;
+    }
+}

--- a/src/main/java/com/backend/gameplay/movement/MovementAuthorityService.java
+++ b/src/main/java/com/backend/gameplay/movement/MovementAuthorityService.java
@@ -1,0 +1,79 @@
+package com.backend.gameplay.movement;
+
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+public class MovementAuthorityService {
+
+    private final GameplayMovementProperties properties;
+
+    public MovementAuthorityService(GameplayMovementProperties properties) {
+        this.properties = properties;
+    }
+
+    public ActiveMovementState initialize(UUID sessionId, UUID playerId, String zoneId, double positionX, double positionY, Instant now) {
+        return new ActiveMovementState(
+                sessionId,
+                playerId,
+                zoneId,
+                positionX,
+                positionY,
+                MovementDirection.NONE,
+                now,
+                null
+        );
+    }
+
+    public AuthoritativeMovementState snapshot(ActiveMovementState state, Instant now) {
+        advanceTo(state, now);
+        return toSnapshot(state);
+    }
+
+    public AuthoritativeMovementState applyIntent(ActiveMovementState state, MovementIntent intent, Instant now) {
+        advanceTo(state, now);
+
+        Instant inputTime = intent.inputTime();
+        if (inputTime != null && isAccepted(state.lastAcceptedInputTime(), inputTime)) {
+            state.setDirection(intent.direction());
+            state.setLastAcceptedInputTime(inputTime);
+        }
+
+        return toSnapshot(state);
+    }
+
+    private boolean isAccepted(Instant lastAcceptedInputTime, Instant inputTime) {
+        return lastAcceptedInputTime == null || !inputTime.isBefore(lastAcceptedInputTime);
+    }
+
+    private void advanceTo(ActiveMovementState state, Instant now) {
+        Duration elapsed = Duration.between(state.lastSimulatedAt(), now);
+        if (elapsed.isNegative() || elapsed.isZero()) {
+            state.setLastSimulatedAt(now);
+            return;
+        }
+
+        double seconds = elapsed.toNanos() / 1_000_000_000d;
+        double distance = properties.getSpeedUnitsPerSecond() * seconds;
+
+        state.setPositionX(state.positionX() + (state.direction().xComponent() * distance));
+        state.setPositionY(state.positionY() + (state.direction().yComponent() * distance));
+        state.setLastSimulatedAt(now);
+    }
+
+    private AuthoritativeMovementState toSnapshot(ActiveMovementState state) {
+        return new AuthoritativeMovementState(
+                state.sessionId(),
+                state.playerId(),
+                state.zoneId(),
+                state.positionX(),
+                state.positionY(),
+                state.direction(),
+                state.lastSimulatedAt(),
+                state.lastAcceptedInputTime()
+        );
+    }
+}

--- a/src/main/java/com/backend/gameplay/movement/MovementDirection.java
+++ b/src/main/java/com/backend/gameplay/movement/MovementDirection.java
@@ -1,0 +1,29 @@
+package com.backend.gameplay.movement;
+
+public enum MovementDirection {
+    NONE(0.0, 0.0),
+    NORTH(0.0, 1.0),
+    NORTH_EAST(0.7071067811865476, 0.7071067811865476),
+    EAST(1.0, 0.0),
+    SOUTH_EAST(0.7071067811865476, -0.7071067811865476),
+    SOUTH(0.0, -1.0),
+    SOUTH_WEST(-0.7071067811865476, -0.7071067811865476),
+    WEST(-1.0, 0.0),
+    NORTH_WEST(-0.7071067811865476, 0.7071067811865476);
+
+    private final double xComponent;
+    private final double yComponent;
+
+    MovementDirection(double xComponent, double yComponent) {
+        this.xComponent = xComponent;
+        this.yComponent = yComponent;
+    }
+
+    public double xComponent() {
+        return xComponent;
+    }
+
+    public double yComponent() {
+        return yComponent;
+    }
+}

--- a/src/main/java/com/backend/gameplay/movement/MovementIntent.java
+++ b/src/main/java/com/backend/gameplay/movement/MovementIntent.java
@@ -1,0 +1,11 @@
+package com.backend.gameplay.movement;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record MovementIntent(
+        UUID sessionId,
+        Instant inputTime,
+        MovementDirection direction
+) {
+}

--- a/src/main/java/com/backend/gameplay/movement/MovementRuntimeService.java
+++ b/src/main/java/com/backend/gameplay/movement/MovementRuntimeService.java
@@ -1,0 +1,69 @@
+package com.backend.gameplay.movement;
+
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class MovementRuntimeService {
+
+    private final MovementAuthorityService movementAuthorityService;
+    private final Clock clock;
+    private final Map<UUID, ActiveMovementState> activeStates = new HashMap<>();
+
+    public MovementRuntimeService(MovementAuthorityService movementAuthorityService, Clock clock) {
+        this.movementAuthorityService = movementAuthorityService;
+        this.clock = clock;
+    }
+
+    public synchronized AuthoritativeMovementState startSession(
+            UUID sessionId,
+            UUID playerId,
+            String zoneId,
+            double positionX,
+            double positionY
+    ) {
+        ActiveMovementState state = movementAuthorityService.initialize(
+                sessionId,
+                playerId,
+                zoneId,
+                positionX,
+                positionY,
+                Instant.now(clock)
+        );
+        activeStates.put(sessionId, state);
+        return movementAuthorityService.snapshot(state, Instant.now(clock));
+    }
+
+    public synchronized Optional<AuthoritativeMovementState> snapshot(UUID sessionId) {
+        ActiveMovementState state = activeStates.get(sessionId);
+        if (state == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(movementAuthorityService.snapshot(state, Instant.now(clock)));
+    }
+
+    public synchronized Optional<AuthoritativeMovementState> applyIntent(MovementIntent intent) {
+        ActiveMovementState state = activeStates.get(intent.sessionId());
+        if (state == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(movementAuthorityService.applyIntent(state, intent, Instant.now(clock)));
+    }
+
+    public synchronized Optional<AuthoritativeMovementState> stopSession(UUID sessionId) {
+        ActiveMovementState state = activeStates.remove(sessionId);
+        if (state == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(movementAuthorityService.snapshot(state, Instant.now(clock)));
+    }
+}

--- a/src/main/java/com/backend/gameplay/session/GameplaySessionController.java
+++ b/src/main/java/com/backend/gameplay/session/GameplaySessionController.java
@@ -1,0 +1,62 @@
+package com.backend.gameplay.session;
+
+import com.backend.api.ApiErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/gameplay/sessions")
+@Tag(name = "Gameplay Sessions", description = "Authenticated control-plane endpoints for gameplay session issuance.")
+public class GameplaySessionController {
+
+    private final GameplaySessionCoordinator gameplaySessionCoordinator;
+
+    public GameplaySessionController(GameplaySessionCoordinator gameplaySessionCoordinator) {
+        this.gameplaySessionCoordinator = gameplaySessionCoordinator;
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "Issue a short-lived gameplay session token",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Gameplay session issued",
+                    content = @Content(schema = @Schema(implementation = GameplaySessionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Missing or invalid bearer token",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
+            )
+    })
+    public ResponseEntity<GameplaySessionResponse> issueSession(@AuthenticationPrincipal Jwt jwt) {
+        GameplaySessionResponse response = gameplaySessionCoordinator.issueSession(
+                jwt.getSubject(),
+                preferredHandle(jwt)
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    private String preferredHandle(Jwt jwt) {
+        String preferredUsername = jwt.getClaimAsString("preferred_username");
+        if (preferredUsername != null && !preferredUsername.isBlank()) {
+            return preferredUsername;
+        }
+
+        return jwt.getSubject();
+    }
+}

--- a/src/main/java/com/backend/gameplay/session/GameplaySessionCoordinator.java
+++ b/src/main/java/com/backend/gameplay/session/GameplaySessionCoordinator.java
@@ -1,0 +1,110 @@
+package com.backend.gameplay.session;
+
+import com.backend.gameplay.movement.AuthoritativeMovementState;
+import com.backend.gameplay.movement.GameplayMovementProperties;
+import com.backend.gameplay.movement.MovementDirection;
+import com.backend.gameplay.movement.MovementIntent;
+import com.backend.gameplay.movement.MovementRuntimeService;
+import com.backend.persistence.player.PlayerLocation;
+import com.backend.persistence.player.PlayerLocationRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class GameplaySessionCoordinator {
+
+    private final PlayerIdentityService playerIdentityService;
+    private final GameplaySessionService gameplaySessionService;
+    private final PlayerLocationRepository playerLocationRepository;
+    private final MovementRuntimeService movementRuntimeService;
+    private final GameplaySessionProperties sessionProperties;
+    private final GameplayMovementProperties movementProperties;
+
+    public GameplaySessionCoordinator(
+            PlayerIdentityService playerIdentityService,
+            GameplaySessionService gameplaySessionService,
+            PlayerLocationRepository playerLocationRepository,
+            MovementRuntimeService movementRuntimeService,
+            GameplaySessionProperties sessionProperties,
+            GameplayMovementProperties movementProperties
+    ) {
+        this.playerIdentityService = playerIdentityService;
+        this.gameplaySessionService = gameplaySessionService;
+        this.playerLocationRepository = playerLocationRepository;
+        this.movementRuntimeService = movementRuntimeService;
+        this.sessionProperties = sessionProperties;
+        this.movementProperties = movementProperties;
+    }
+
+    public GameplaySessionResponse issueSession(String externalSubject, String preferredHandle) {
+        PlayerIdentity playerIdentity = playerIdentityService.resolvePlayer(externalSubject, preferredHandle);
+        closeExistingSession(playerIdentity.playerId());
+
+        PlayerLocation startingLocation = playerLocationRepository.findByPlayerId(playerIdentity.playerId())
+                .orElseGet(() -> new PlayerLocation(
+                        playerIdentity.playerId(),
+                        movementProperties.getDefaultZoneId(),
+                        0.0,
+                        0.0,
+                        null
+                ));
+
+        GameplaySessionTicket sessionTicket = gameplaySessionService.issue(playerIdentity.playerId(), playerIdentity.handle());
+        AuthoritativeMovementState initialState = movementRuntimeService.startSession(
+                sessionTicket.sessionId(),
+                playerIdentity.playerId(),
+                startingLocation.zoneId(),
+                startingLocation.positionX(),
+                startingLocation.positionY()
+        );
+
+        return new GameplaySessionResponse(
+                sessionTicket.sessionId(),
+                sessionTicket.playerId(),
+                sessionTicket.playerHandle(),
+                sessionTicket.sessionToken(),
+                sessionTicket.expiresAt(),
+                "websocket",
+                sessionProperties.getWebsocketPath(),
+                initialState
+        );
+    }
+
+    public Optional<GameplaySessionTicket> validateConnection(UUID sessionId, String sessionToken) {
+        return gameplaySessionService.validate(sessionId, sessionToken);
+    }
+
+    public boolean attachConnection(UUID sessionId, String connectionId) {
+        return gameplaySessionService.attach(sessionId, connectionId);
+    }
+
+    public Optional<AuthoritativeMovementState> currentState(UUID sessionId) {
+        return movementRuntimeService.snapshot(sessionId);
+    }
+
+    public Optional<AuthoritativeMovementState> applyIntent(UUID sessionId, Instant inputTime, MovementDirection direction) {
+        return movementRuntimeService.applyIntent(new MovementIntent(sessionId, inputTime, direction));
+    }
+
+    public void closeSession(UUID sessionId) {
+        Optional<AuthoritativeMovementState> finalState = movementRuntimeService.stopSession(sessionId);
+        gameplaySessionService.close(sessionId);
+        finalState.ifPresent(this::persistLocation);
+    }
+
+    private void closeExistingSession(UUID playerId) {
+        gameplaySessionService.findActiveSessionId(playerId).ifPresent(this::closeSession);
+    }
+
+    private void persistLocation(AuthoritativeMovementState state) {
+        playerLocationRepository.upsert(
+                state.playerId(),
+                state.zoneId(),
+                state.positionX(),
+                state.positionY()
+        );
+    }
+}

--- a/src/main/java/com/backend/gameplay/session/GameplaySessionCoordinator.java
+++ b/src/main/java/com/backend/gameplay/session/GameplaySessionCoordinator.java
@@ -95,6 +95,16 @@ public class GameplaySessionCoordinator {
         finalState.ifPresent(this::persistLocation);
     }
 
+    public boolean closeConnection(UUID sessionId, String connectionId) {
+        Optional<GameplaySessionTicket> closedSession = gameplaySessionService.closeAttached(sessionId, connectionId);
+        if (closedSession.isEmpty()) {
+            return false;
+        }
+
+        movementRuntimeService.stopSession(sessionId).ifPresent(this::persistLocation);
+        return true;
+    }
+
     private void closeExistingSession(UUID playerId) {
         gameplaySessionService.findActiveSessionId(playerId).ifPresent(this::closeSession);
     }

--- a/src/main/java/com/backend/gameplay/session/GameplaySessionProperties.java
+++ b/src/main/java/com/backend/gameplay/session/GameplaySessionProperties.java
@@ -1,0 +1,28 @@
+package com.backend.gameplay.session;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "app.gameplay.session")
+public class GameplaySessionProperties {
+
+    private Duration tokenTtl = Duration.ofMinutes(5);
+    private String websocketPath = "/ws/gameplay";
+
+    public Duration getTokenTtl() {
+        return tokenTtl;
+    }
+
+    public void setTokenTtl(Duration tokenTtl) {
+        this.tokenTtl = tokenTtl;
+    }
+
+    public String getWebsocketPath() {
+        return websocketPath;
+    }
+
+    public void setWebsocketPath(String websocketPath) {
+        this.websocketPath = websocketPath;
+    }
+}

--- a/src/main/java/com/backend/gameplay/session/GameplaySessionResponse.java
+++ b/src/main/java/com/backend/gameplay/session/GameplaySessionResponse.java
@@ -1,0 +1,18 @@
+package com.backend.gameplay.session;
+
+import com.backend.gameplay.movement.AuthoritativeMovementState;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record GameplaySessionResponse(
+        UUID sessionId,
+        UUID playerId,
+        String playerHandle,
+        String sessionToken,
+        Instant expiresAt,
+        String transport,
+        String websocketPath,
+        AuthoritativeMovementState initialState
+) {
+}

--- a/src/main/java/com/backend/gameplay/session/GameplaySessionService.java
+++ b/src/main/java/com/backend/gameplay/session/GameplaySessionService.java
@@ -1,0 +1,123 @@
+package com.backend.gameplay.session;
+
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class GameplaySessionService {
+
+    private final GameplaySessionProperties properties;
+    private final Clock clock;
+    private final SecureRandom secureRandom = new SecureRandom();
+    private final Map<UUID, StoredGameplaySession> sessionsById = new HashMap<>();
+    private final Map<UUID, UUID> sessionIdByPlayerId = new HashMap<>();
+
+    public GameplaySessionService(GameplaySessionProperties properties, Clock clock) {
+        this.properties = properties;
+        this.clock = clock;
+    }
+
+    public synchronized GameplaySessionTicket issue(UUID playerId, String playerHandle) {
+        Instant issuedAt = Instant.now(clock);
+        Instant expiresAt = issuedAt.plus(properties.getTokenTtl());
+        UUID sessionId = UUID.randomUUID();
+        String sessionToken = generateSessionToken();
+
+        StoredGameplaySession stored = new StoredGameplaySession(
+                sessionId,
+                playerId,
+                playerHandle,
+                sessionToken,
+                issuedAt,
+                expiresAt
+        );
+        sessionsById.put(sessionId, stored);
+        sessionIdByPlayerId.put(playerId, sessionId);
+        return stored.toTicket();
+    }
+
+    public synchronized Optional<UUID> findActiveSessionId(UUID playerId) {
+        return Optional.ofNullable(sessionIdByPlayerId.get(playerId));
+    }
+
+    public synchronized Optional<GameplaySessionTicket> validate(UUID sessionId, String sessionToken) {
+        StoredGameplaySession stored = sessionsById.get(sessionId);
+        if (stored == null || !stored.matches(sessionToken) || stored.isExpired(Instant.now(clock))) {
+            return Optional.empty();
+        }
+
+        return Optional.of(stored.toTicket());
+    }
+
+    public synchronized boolean attach(UUID sessionId, String connectionId) {
+        StoredGameplaySession stored = sessionsById.get(sessionId);
+        if (stored == null || stored.connectionId != null) {
+            return false;
+        }
+
+        stored.connectionId = connectionId;
+        return true;
+    }
+
+    public synchronized Optional<GameplaySessionTicket> close(UUID sessionId) {
+        StoredGameplaySession stored = sessionsById.remove(sessionId);
+        if (stored == null) {
+            return Optional.empty();
+        }
+
+        sessionIdByPlayerId.remove(stored.playerId, sessionId);
+        return Optional.of(stored.toTicket());
+    }
+
+    private String generateSessionToken() {
+        byte[] bytes = new byte[24];
+        secureRandom.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private static final class StoredGameplaySession {
+        private final UUID sessionId;
+        private final UUID playerId;
+        private final String playerHandle;
+        private final String sessionToken;
+        private final Instant issuedAt;
+        private final Instant expiresAt;
+        private String connectionId;
+
+        private StoredGameplaySession(
+                UUID sessionId,
+                UUID playerId,
+                String playerHandle,
+                String sessionToken,
+                Instant issuedAt,
+                Instant expiresAt
+        ) {
+            this.sessionId = sessionId;
+            this.playerId = playerId;
+            this.playerHandle = playerHandle;
+            this.sessionToken = sessionToken;
+            this.issuedAt = issuedAt;
+            this.expiresAt = expiresAt;
+        }
+
+        private boolean matches(String candidateToken) {
+            return sessionToken.equals(candidateToken);
+        }
+
+        private boolean isExpired(Instant now) {
+            return expiresAt.isBefore(now);
+        }
+
+        private GameplaySessionTicket toTicket() {
+            return new GameplaySessionTicket(sessionId, playerId, playerHandle, sessionToken, issuedAt, expiresAt);
+        }
+    }
+}

--- a/src/main/java/com/backend/gameplay/session/GameplaySessionService.java
+++ b/src/main/java/com/backend/gameplay/session/GameplaySessionService.java
@@ -77,6 +77,17 @@ public class GameplaySessionService {
         return Optional.of(stored.toTicket());
     }
 
+    public synchronized Optional<GameplaySessionTicket> closeAttached(UUID sessionId, String connectionId) {
+        StoredGameplaySession stored = sessionsById.get(sessionId);
+        if (stored == null || stored.connectionId == null || !stored.connectionId.equals(connectionId)) {
+            return Optional.empty();
+        }
+
+        sessionsById.remove(sessionId);
+        sessionIdByPlayerId.remove(stored.playerId, sessionId);
+        return Optional.of(stored.toTicket());
+    }
+
     private String generateSessionToken() {
         byte[] bytes = new byte[24];
         secureRandom.nextBytes(bytes);

--- a/src/main/java/com/backend/gameplay/session/GameplaySessionTicket.java
+++ b/src/main/java/com/backend/gameplay/session/GameplaySessionTicket.java
@@ -1,0 +1,14 @@
+package com.backend.gameplay.session;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record GameplaySessionTicket(
+        UUID sessionId,
+        UUID playerId,
+        String playerHandle,
+        String sessionToken,
+        Instant issuedAt,
+        Instant expiresAt
+) {
+}

--- a/src/main/java/com/backend/gameplay/session/PlayerIdentity.java
+++ b/src/main/java/com/backend/gameplay/session/PlayerIdentity.java
@@ -1,0 +1,11 @@
+package com.backend.gameplay.session;
+
+import java.util.UUID;
+
+public record PlayerIdentity(
+        UUID playerId,
+        String externalSubject,
+        String handle,
+        String displayName
+) {
+}

--- a/src/main/java/com/backend/gameplay/session/PlayerIdentityService.java
+++ b/src/main/java/com/backend/gameplay/session/PlayerIdentityService.java
@@ -1,0 +1,39 @@
+package com.backend.gameplay.session;
+
+import com.backend.persistence.player.PlayerProfile;
+import com.backend.persistence.player.PlayerProfileRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PlayerIdentityService {
+
+    private static final int MAX_HANDLE_LENGTH = 32;
+    private static final int MAX_DISPLAY_NAME_LENGTH = 64;
+
+    private final PlayerProfileRepository playerProfileRepository;
+
+    public PlayerIdentityService(PlayerProfileRepository playerProfileRepository) {
+        this.playerProfileRepository = playerProfileRepository;
+    }
+
+    public PlayerIdentity resolvePlayer(String externalSubject, String preferredHandle) {
+        String normalizedHandle = normalize(preferredHandle, MAX_HANDLE_LENGTH, "player");
+        String displayName = normalize(preferredHandle, MAX_DISPLAY_NAME_LENGTH, normalizedHandle);
+
+        PlayerProfile profile = playerProfileRepository.findOrCreate(externalSubject, normalizedHandle, displayName);
+        return new PlayerIdentity(profile.id(), profile.externalSubject(), profile.handle(), profile.displayName());
+    }
+
+    private String normalize(String candidate, int maxLength, String fallback) {
+        if (candidate == null || candidate.isBlank()) {
+            return fallback;
+        }
+
+        String trimmed = candidate.trim();
+        if (trimmed.length() <= maxLength) {
+            return trimmed;
+        }
+
+        return trimmed.substring(0, maxLength);
+    }
+}

--- a/src/main/java/com/backend/gameplay/transport/GameplayHandshakeInterceptor.java
+++ b/src/main/java/com/backend/gameplay/transport/GameplayHandshakeInterceptor.java
@@ -1,0 +1,74 @@
+package com.backend.gameplay.transport;
+
+import com.backend.gameplay.session.GameplaySessionCoordinator;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class GameplayHandshakeInterceptor implements HandshakeInterceptor {
+
+    static final String GAMEPLAY_SESSION_ID_ATTRIBUTE = "gameplaySessionId";
+
+    private final GameplaySessionCoordinator gameplaySessionCoordinator;
+
+    public GameplayHandshakeInterceptor(GameplaySessionCoordinator gameplaySessionCoordinator) {
+        this.gameplaySessionCoordinator = gameplaySessionCoordinator;
+    }
+
+    @Override
+    public boolean beforeHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Map<String, Object> attributes
+    ) {
+        if (!(request instanceof ServletServerHttpRequest servletRequest)) {
+            return false;
+        }
+
+        String sessionIdParam = servletRequest.getServletRequest().getParameter("sessionId");
+        String tokenParam = servletRequest.getServletRequest().getParameter("token");
+
+        Optional<UUID> sessionId = parseUuid(sessionIdParam);
+        if (sessionId.isEmpty() || tokenParam == null || tokenParam.isBlank()) {
+            return false;
+        }
+
+        return gameplaySessionCoordinator.validateConnection(sessionId.get(), tokenParam)
+                .map(ticket -> {
+                    attributes.put(GAMEPLAY_SESSION_ID_ATTRIBUTE, ticket.sessionId());
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    @Override
+    public void afterHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Exception exception
+    ) {
+        // no-op
+    }
+
+    private Optional<UUID> parseUuid(String candidate) {
+        if (candidate == null || candidate.isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(UUID.fromString(candidate));
+        } catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/backend/gameplay/transport/GameplaySocketMessage.java
+++ b/src/main/java/com/backend/gameplay/transport/GameplaySocketMessage.java
@@ -1,0 +1,9 @@
+package com.backend.gameplay.transport;
+
+import com.backend.gameplay.movement.AuthoritativeMovementState;
+
+public record GameplaySocketMessage(
+        String type,
+        AuthoritativeMovementState state
+) {
+}

--- a/src/main/java/com/backend/gameplay/transport/GameplayWebSocketConfig.java
+++ b/src/main/java/com/backend/gameplay/transport/GameplayWebSocketConfig.java
@@ -1,0 +1,33 @@
+package com.backend.gameplay.transport;
+
+import com.backend.gameplay.session.GameplaySessionProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+public class GameplayWebSocketConfig implements WebSocketConfigurer {
+
+    private final GameplayWebSocketHandler gameplayWebSocketHandler;
+    private final GameplayHandshakeInterceptor gameplayHandshakeInterceptor;
+    private final GameplaySessionProperties gameplaySessionProperties;
+
+    public GameplayWebSocketConfig(
+            GameplayWebSocketHandler gameplayWebSocketHandler,
+            GameplayHandshakeInterceptor gameplayHandshakeInterceptor,
+            GameplaySessionProperties gameplaySessionProperties
+    ) {
+        this.gameplayWebSocketHandler = gameplayWebSocketHandler;
+        this.gameplayHandshakeInterceptor = gameplayHandshakeInterceptor;
+        this.gameplaySessionProperties = gameplaySessionProperties;
+    }
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(gameplayWebSocketHandler, gameplaySessionProperties.getWebsocketPath())
+                .addInterceptors(gameplayHandshakeInterceptor)
+                .setAllowedOriginPatterns("*");
+    }
+}

--- a/src/main/java/com/backend/gameplay/transport/GameplayWebSocketHandler.java
+++ b/src/main/java/com/backend/gameplay/transport/GameplayWebSocketHandler.java
@@ -74,12 +74,14 @@ public class GameplayWebSocketHandler extends TextWebSocketHandler {
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
-        gameplaySessionId(session).ifPresent(gameplaySessionCoordinator::closeSession);
+        gameplaySessionId(session).ifPresent(sessionId ->
+                gameplaySessionCoordinator.closeConnection(sessionId, session.getId()));
     }
 
     @Override
     public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
-        gameplaySessionId(session).ifPresent(gameplaySessionCoordinator::closeSession);
+        gameplaySessionId(session).ifPresent(sessionId ->
+                gameplaySessionCoordinator.closeConnection(sessionId, session.getId()));
         if (session.isOpen()) {
             session.close(CloseStatus.SERVER_ERROR);
         }

--- a/src/main/java/com/backend/gameplay/transport/GameplayWebSocketHandler.java
+++ b/src/main/java/com/backend/gameplay/transport/GameplayWebSocketHandler.java
@@ -1,0 +1,109 @@
+package com.backend.gameplay.transport;
+
+import com.backend.gameplay.movement.AuthoritativeMovementState;
+import com.backend.gameplay.movement.MovementDirection;
+import com.backend.gameplay.session.GameplaySessionCoordinator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class GameplayWebSocketHandler extends TextWebSocketHandler {
+
+    private final GameplaySessionCoordinator gameplaySessionCoordinator;
+    private final ObjectMapper objectMapper;
+
+    public GameplayWebSocketHandler(
+            GameplaySessionCoordinator gameplaySessionCoordinator,
+            ObjectMapper objectMapper
+    ) {
+        this.gameplaySessionCoordinator = gameplaySessionCoordinator;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        Optional<UUID> sessionId = gameplaySessionId(session);
+        if (sessionId.isEmpty() || !gameplaySessionCoordinator.attachConnection(sessionId.get(), session.getId())) {
+            session.close(CloseStatus.POLICY_VIOLATION);
+            return;
+        }
+
+        Optional<AuthoritativeMovementState> initialState = gameplaySessionCoordinator.currentState(sessionId.get());
+        if (initialState.isEmpty()) {
+            session.close(CloseStatus.SERVER_ERROR);
+            return;
+        }
+
+        sendState(session, "position", initialState.get());
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        Optional<UUID> sessionId = gameplaySessionId(session);
+        if (sessionId.isEmpty()) {
+            session.close(CloseStatus.POLICY_VIOLATION);
+            return;
+        }
+
+        MovementIntentMessage intent = readIntent(message);
+        MovementDirection direction = intent.direction() == null ? MovementDirection.NONE : intent.direction();
+        Instant inputTime = intent.inputTime() == null ? Instant.now() : intent.inputTime();
+
+        Optional<AuthoritativeMovementState> updatedState = gameplaySessionCoordinator.applyIntent(
+                sessionId.get(),
+                inputTime,
+                direction
+        );
+        if (updatedState.isEmpty()) {
+            session.close(CloseStatus.POLICY_VIOLATION);
+            return;
+        }
+
+        sendState(session, "position", updatedState.get());
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        gameplaySessionId(session).ifPresent(gameplaySessionCoordinator::closeSession);
+    }
+
+    @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
+        gameplaySessionId(session).ifPresent(gameplaySessionCoordinator::closeSession);
+        if (session.isOpen()) {
+            session.close(CloseStatus.SERVER_ERROR);
+        }
+    }
+
+    private MovementIntentMessage readIntent(TextMessage message) throws IOException {
+        try {
+            return objectMapper.readValue(message.getPayload(), MovementIntentMessage.class);
+        } catch (JsonProcessingException exception) {
+            throw new IOException("Invalid movement intent payload", exception);
+        }
+    }
+
+    private void sendState(WebSocketSession session, String type, AuthoritativeMovementState state) throws IOException {
+        GameplaySocketMessage socketMessage = new GameplaySocketMessage(type, state);
+        session.sendMessage(new TextMessage(objectMapper.writeValueAsString(socketMessage)));
+    }
+
+    private Optional<UUID> gameplaySessionId(WebSocketSession session) {
+        Object attribute = session.getAttributes().get(GameplayHandshakeInterceptor.GAMEPLAY_SESSION_ID_ATTRIBUTE);
+        if (attribute instanceof UUID sessionId) {
+            return Optional.of(sessionId);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/backend/gameplay/transport/MovementIntentMessage.java
+++ b/src/main/java/com/backend/gameplay/transport/MovementIntentMessage.java
@@ -1,0 +1,11 @@
+package com.backend.gameplay.transport;
+
+import com.backend.gameplay.movement.MovementDirection;
+
+import java.time.Instant;
+
+public record MovementIntentMessage(
+        Instant inputTime,
+        MovementDirection direction
+) {
+}

--- a/src/main/java/com/backend/persistence/player/PlayerLocation.java
+++ b/src/main/java/com/backend/persistence/player/PlayerLocation.java
@@ -1,0 +1,13 @@
+package com.backend.persistence.player;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record PlayerLocation(
+        UUID playerId,
+        String zoneId,
+        double positionX,
+        double positionY,
+        OffsetDateTime updatedAt
+) {
+}

--- a/src/main/java/com/backend/persistence/player/PlayerLocationRepository.java
+++ b/src/main/java/com/backend/persistence/player/PlayerLocationRepository.java
@@ -1,0 +1,63 @@
+package com.backend.persistence.player;
+
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class PlayerLocationRepository {
+
+    private final JdbcClient jdbcClient;
+
+    public PlayerLocationRepository(JdbcClient jdbcClient) {
+        this.jdbcClient = jdbcClient;
+    }
+
+    public Optional<PlayerLocation> findByPlayerId(UUID playerId) {
+        return jdbcClient.sql("""
+                select player_id, zone_id, position_x, position_y, updated_at
+                from player_location
+                where player_id = :playerId
+                """)
+                .param("playerId", playerId)
+                .query(this::mapRow)
+                .optional();
+    }
+
+    public PlayerLocation upsert(UUID playerId, String zoneId, double positionX, double positionY) {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        jdbcClient.sql("""
+                insert into player_location (player_id, zone_id, position_x, position_y, updated_at)
+                values (:playerId, :zoneId, :positionX, :positionY, :updatedAt)
+                on conflict (player_id) do update
+                set zone_id = excluded.zone_id,
+                    position_x = excluded.position_x,
+                    position_y = excluded.position_y,
+                    updated_at = excluded.updated_at
+                """)
+                .param("playerId", playerId)
+                .param("zoneId", zoneId)
+                .param("positionX", positionX)
+                .param("positionY", positionY)
+                .param("updatedAt", now)
+                .update();
+
+        return new PlayerLocation(playerId, zoneId, positionX, positionY, now);
+    }
+
+    private PlayerLocation mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return new PlayerLocation(
+                rs.getObject("player_id", UUID.class),
+                rs.getString("zone_id"),
+                rs.getDouble("position_x"),
+                rs.getDouble("position_y"),
+                rs.getObject("updated_at", OffsetDateTime.class)
+        );
+    }
+}

--- a/src/main/java/com/backend/persistence/player/PlayerProfile.java
+++ b/src/main/java/com/backend/persistence/player/PlayerProfile.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 public record PlayerProfile(
         UUID id,
+        String externalSubject,
         String handle,
         String displayName,
         OffsetDateTime createdAt,

--- a/src/main/java/com/backend/persistence/player/PlayerProfileRepository.java
+++ b/src/main/java/com/backend/persistence/player/PlayerProfileRepository.java
@@ -39,8 +39,24 @@ public class PlayerProfileRepository {
     }
 
     public PlayerProfile findOrCreate(String externalSubject, String handle, String displayName) {
-        return findByExternalSubject(externalSubject)
-                .orElseGet(() -> create(externalSubject, handle, displayName));
+        UUID id = UUID.randomUUID();
+        OffsetDateTime now = OffsetDateTime.now();
+
+        return jdbcClient.sql("""
+                insert into player_profile (id, external_subject, handle, display_name, created_at, updated_at)
+                values (:id, :externalSubject, :handle, :displayName, :createdAt, :updatedAt)
+                on conflict (external_subject) do update
+                set external_subject = excluded.external_subject
+                returning id, external_subject, handle, display_name, created_at, updated_at
+                """)
+                .param("id", id)
+                .param("externalSubject", externalSubject)
+                .param("handle", handle)
+                .param("displayName", displayName)
+                .param("createdAt", now)
+                .param("updatedAt", now)
+                .query(this::mapRow)
+                .single();
     }
 
     public Optional<PlayerProfile> findById(UUID id) {

--- a/src/main/java/com/backend/persistence/player/PlayerProfileRepository.java
+++ b/src/main/java/com/backend/persistence/player/PlayerProfileRepository.java
@@ -19,27 +19,33 @@ public class PlayerProfileRepository {
         this.jdbcClient = jdbcClient;
     }
 
-    public PlayerProfile create(String handle, String displayName) {
+    public PlayerProfile create(String externalSubject, String handle, String displayName) {
         UUID id = UUID.randomUUID();
         OffsetDateTime now = OffsetDateTime.now();
 
         jdbcClient.sql("""
-                insert into player_profile (id, handle, display_name, created_at, updated_at)
-                values (:id, :handle, :displayName, :createdAt, :updatedAt)
+                insert into player_profile (id, external_subject, handle, display_name, created_at, updated_at)
+                values (:id, :externalSubject, :handle, :displayName, :createdAt, :updatedAt)
                 """)
                 .param("id", id)
+                .param("externalSubject", externalSubject)
                 .param("handle", handle)
                 .param("displayName", displayName)
                 .param("createdAt", now)
                 .param("updatedAt", now)
                 .update();
 
-        return new PlayerProfile(id, handle, displayName, now, now);
+        return new PlayerProfile(id, externalSubject, handle, displayName, now, now);
+    }
+
+    public PlayerProfile findOrCreate(String externalSubject, String handle, String displayName) {
+        return findByExternalSubject(externalSubject)
+                .orElseGet(() -> create(externalSubject, handle, displayName));
     }
 
     public Optional<PlayerProfile> findById(UUID id) {
         return jdbcClient.sql("""
-                select id, handle, display_name, created_at, updated_at
+                select id, external_subject, handle, display_name, created_at, updated_at
                 from player_profile
                 where id = :id
                 """)
@@ -48,9 +54,20 @@ public class PlayerProfileRepository {
                 .optional();
     }
 
+    public Optional<PlayerProfile> findByExternalSubject(String externalSubject) {
+        return jdbcClient.sql("""
+                select id, external_subject, handle, display_name, created_at, updated_at
+                from player_profile
+                where external_subject = :externalSubject
+                """)
+                .param("externalSubject", externalSubject)
+                .query(this::mapRow)
+                .optional();
+    }
+
     public Optional<PlayerProfile> findByHandle(String handle) {
         return jdbcClient.sql("""
-                select id, handle, display_name, created_at, updated_at
+                select id, external_subject, handle, display_name, created_at, updated_at
                 from player_profile
                 where handle = :handle
                 """)
@@ -61,7 +78,7 @@ public class PlayerProfileRepository {
 
     public List<PlayerProfile> findAll() {
         return jdbcClient.sql("""
-                select id, handle, display_name, created_at, updated_at
+                select id, external_subject, handle, display_name, created_at, updated_at
                 from player_profile
                 order by created_at asc
                 """)
@@ -79,6 +96,7 @@ public class PlayerProfileRepository {
     private PlayerProfile mapRow(ResultSet rs, int rowNum) throws SQLException {
         return new PlayerProfile(
                 rs.getObject("id", UUID.class),
+                rs.getString("external_subject"),
                 rs.getString("handle"),
                 rs.getString("display_name"),
                 rs.getObject("created_at", OffsetDateTime.class),

--- a/src/main/java/com/backend/security/SecurityConfig.java
+++ b/src/main/java/com/backend/security/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/ping", "/api/access/public").permitAll()
                         .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/api/access/admin").hasRole("ADMIN")
                         .requestMatchers("/api/access/user").hasAnyRole("USER", "ADMIN")
                         .anyRequest().authenticated()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,3 +48,10 @@ app:
       required-audience: ${KEYCLOAK_REQUIRED_AUDIENCE:game-backend}
       allowed-authorized-parties: ${KEYCLOAK_ALLOWED_AUTHORIZED_PARTIES:game-backend-cli}
       principal-claim: ${KEYCLOAK_PRINCIPAL_CLAIM:preferred_username}
+  gameplay:
+    session:
+      token-ttl: ${GAMEPLAY_SESSION_TOKEN_TTL:PT5M}
+      websocket-path: ${GAMEPLAY_WEBSOCKET_PATH:/ws/gameplay}
+    movement:
+      speed-units-per-second: ${GAMEPLAY_MOVEMENT_SPEED_UNITS_PER_SECOND:4.0}
+      default-zone-id: ${GAMEPLAY_DEFAULT_ZONE_ID:starter-zone}

--- a/src/main/resources/db/migration/V2__add_player_identity_and_location.sql
+++ b/src/main/resources/db/migration/V2__add_player_identity_and_location.sql
@@ -1,0 +1,23 @@
+alter table player_profile
+    add column if not exists external_subject varchar(128);
+
+update player_profile
+set external_subject = handle
+where external_subject is null;
+
+alter table player_profile
+    alter column external_subject set not null;
+
+alter table player_profile
+    add constraint uq_player_profile_external_subject unique (external_subject);
+
+create table if not exists player_location (
+    player_id uuid primary key references player_profile (id) on delete cascade,
+    zone_id varchar(64) not null,
+    position_x double precision not null,
+    position_y double precision not null,
+    updated_at timestamptz not null,
+    constraint chk_player_location_zone_not_blank check (btrim(zone_id) <> '')
+);
+
+create index if not exists ix_player_location_zone_id on player_location (zone_id);

--- a/src/test/java/com/backend/gameplay/movement/MovementAuthorityServiceTest.java
+++ b/src/test/java/com/backend/gameplay/movement/MovementAuthorityServiceTest.java
@@ -1,0 +1,105 @@
+package com.backend.gameplay.movement;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+class MovementAuthorityServiceTest {
+
+    private final GameplayMovementProperties properties = new GameplayMovementProperties();
+    private final MovementAuthorityService movementAuthorityService = new MovementAuthorityService(properties);
+
+    @Test
+    void computesAuthoritativePositionFromAcceptedIntentAndElapsedTime() {
+        Instant start = Instant.parse("2026-04-11T08:00:00Z");
+        ActiveMovementState state = movementAuthorityService.initialize(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "starter-zone",
+                0.0,
+                0.0,
+                start
+        );
+
+        movementAuthorityService.applyIntent(
+                state,
+                new MovementIntent(state.sessionId(), start, MovementDirection.EAST),
+                start
+        );
+
+        AuthoritativeMovementState moved = movementAuthorityService.snapshot(state, start.plusSeconds(1));
+        AuthoritativeMovementState stopped = movementAuthorityService.applyIntent(
+                state,
+                new MovementIntent(state.sessionId(), start.plusMillis(1500), MovementDirection.NONE),
+                start.plusMillis(1500)
+        );
+        AuthoritativeMovementState afterStop = movementAuthorityService.snapshot(state, start.plusSeconds(2));
+
+        assertThat(moved.positionX()).isCloseTo(4.0, offset(0.0001));
+        assertThat(moved.positionY()).isZero();
+        assertThat(stopped.positionX()).isCloseTo(6.0, offset(0.0001));
+        assertThat(stopped.direction()).isEqualTo(MovementDirection.NONE);
+        assertThat(afterStop.positionX()).isCloseTo(6.0, offset(0.0001));
+        assertThat(afterStop.positionY()).isZero();
+    }
+
+    @Test
+    void normalizesDiagonalMovementSpeed() {
+        Instant start = Instant.parse("2026-04-11T08:00:00Z");
+        ActiveMovementState state = movementAuthorityService.initialize(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "starter-zone",
+                0.0,
+                0.0,
+                start
+        );
+
+        movementAuthorityService.applyIntent(
+                state,
+                new MovementIntent(state.sessionId(), start, MovementDirection.NORTH_EAST),
+                start
+        );
+
+        AuthoritativeMovementState moved = movementAuthorityService.snapshot(state, start.plusSeconds(1));
+
+        assertThat(moved.positionX()).isCloseTo(4.0 / Math.sqrt(2.0), offset(0.0001));
+        assertThat(moved.positionY()).isCloseTo(4.0 / Math.sqrt(2.0), offset(0.0001));
+    }
+
+    @Test
+    void ignoresOutOfOrderMovementIntentTimestamps() {
+        Instant start = Instant.parse("2026-04-11T08:00:00Z");
+        ActiveMovementState state = movementAuthorityService.initialize(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "starter-zone",
+                0.0,
+                0.0,
+                start
+        );
+
+        movementAuthorityService.applyIntent(
+                state,
+                new MovementIntent(state.sessionId(), start.plusMillis(100), MovementDirection.EAST),
+                start.plusMillis(100)
+        );
+
+        AuthoritativeMovementState afterLateIntent = movementAuthorityService.applyIntent(
+                state,
+                new MovementIntent(state.sessionId(), start.plusMillis(50), MovementDirection.NORTH),
+                start.plusMillis(1100)
+        );
+        AuthoritativeMovementState finalState = movementAuthorityService.snapshot(state, start.plusMillis(2100));
+
+        assertThat(afterLateIntent.direction()).isEqualTo(MovementDirection.EAST);
+        assertThat(afterLateIntent.positionX()).isCloseTo(4.0, offset(0.0001));
+        assertThat(finalState.direction()).isEqualTo(MovementDirection.EAST);
+        assertThat(finalState.positionX()).isCloseTo(8.0, offset(0.0001));
+        assertThat(finalState.positionY()).isZero();
+    }
+}

--- a/src/test/java/com/backend/gameplay/session/GameplaySessionServiceTest.java
+++ b/src/test/java/com/backend/gameplay/session/GameplaySessionServiceTest.java
@@ -1,0 +1,45 @@
+package com.backend.gameplay.session;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GameplaySessionServiceTest {
+
+    private final GameplaySessionProperties properties = new GameplaySessionProperties();
+    private final Clock clock = Clock.fixed(Instant.parse("2026-04-11T08:00:00Z"), ZoneOffset.UTC);
+    private final GameplaySessionService service = new GameplaySessionService(properties, clock);
+
+    @Test
+    void ignoresCloseRequestsForDifferentConnectionId() {
+        UUID playerId = UUID.randomUUID();
+        GameplaySessionTicket ticket = service.issue(playerId, "ahri");
+
+        assertThat(service.attach(ticket.sessionId(), "active-connection")).isTrue();
+
+        Optional<GameplaySessionTicket> closed = service.closeAttached(ticket.sessionId(), "replayed-connection");
+
+        assertThat(closed).isEmpty();
+        assertThat(service.validate(ticket.sessionId(), ticket.sessionToken())).contains(ticket);
+    }
+
+    @Test
+    void closesSessionForAttachedConnectionId() {
+        UUID playerId = UUID.randomUUID();
+        GameplaySessionTicket ticket = service.issue(playerId, "ahri");
+
+        assertThat(service.attach(ticket.sessionId(), "active-connection")).isTrue();
+
+        Optional<GameplaySessionTicket> closed = service.closeAttached(ticket.sessionId(), "active-connection");
+
+        assertThat(closed).contains(ticket);
+        assertThat(service.validate(ticket.sessionId(), ticket.sessionToken())).isEmpty();
+        assertThat(service.findActiveSessionId(playerId)).isEmpty();
+    }
+}

--- a/src/test/java/com/backend/gameplay/transport/GameplayWebSocketHandlerTest.java
+++ b/src/test/java/com/backend/gameplay/transport/GameplayWebSocketHandlerTest.java
@@ -1,0 +1,35 @@
+package com.backend.gameplay.transport;
+
+import com.backend.gameplay.session.GameplaySessionCoordinator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GameplayWebSocketHandlerTest {
+
+    @Test
+    void closesOnlyTheAttachedConnectionWhenSocketEnds() {
+        GameplaySessionCoordinator gameplaySessionCoordinator = mock(GameplaySessionCoordinator.class);
+        GameplayWebSocketHandler handler = new GameplayWebSocketHandler(gameplaySessionCoordinator, new ObjectMapper());
+        WebSocketSession session = mock(WebSocketSession.class);
+        UUID sessionId = UUID.randomUUID();
+
+        when(session.getId()).thenReturn("active-connection");
+        when(session.getAttributes()).thenReturn(Map.of(
+                GameplayHandshakeInterceptor.GAMEPLAY_SESSION_ID_ATTRIBUTE,
+                sessionId
+        ));
+
+        handler.afterConnectionClosed(session, CloseStatus.NORMAL);
+
+        verify(gameplaySessionCoordinator).closeConnection(sessionId, "active-connection");
+    }
+}

--- a/src/test/java/com/backend/integration/GameplaySessionIntegrationTest.java
+++ b/src/test/java/com/backend/integration/GameplaySessionIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.backend.integration;
+
+import com.backend.persistence.player.PlayerProfileRepository;
+import com.backend.support.PostgresIntegrationTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class GameplaySessionIntegrationTest extends PostgresIntegrationTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PlayerProfileRepository playerProfileRepository;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void issuesGameplaySessionForAuthenticatedPlayer() throws Exception {
+        mockMvc.perform(post("/api/gameplay/sessions")
+                        .with(jwt().jwt(jwt -> jwt
+                                .subject("subject-ahri")
+                                .claim("preferred_username", "ahri"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.playerHandle").value("ahri"))
+                .andExpect(jsonPath("$.transport").value("websocket"))
+                .andExpect(jsonPath("$.websocketPath").value("/ws/gameplay"))
+                .andExpect(jsonPath("$.sessionId").isNotEmpty())
+                .andExpect(jsonPath("$.sessionToken").isNotEmpty())
+                .andExpect(jsonPath("$.initialState.zoneId").value("starter-zone"))
+                .andExpect(jsonPath("$.initialState.positionX").value(0.0))
+                .andExpect(jsonPath("$.initialState.positionY").value(0.0));
+
+        assertThat(playerProfileRepository.findByExternalSubject("subject-ahri")).isPresent();
+        assertThat(playerProfileRepository.findByExternalSubject("subject-ahri").orElseThrow().handle()).isEqualTo("ahri");
+    }
+}

--- a/src/test/java/com/backend/integration/PlayerLocationRepositoryIntegrationTest.java
+++ b/src/test/java/com/backend/integration/PlayerLocationRepositoryIntegrationTest.java
@@ -1,0 +1,46 @@
+package com.backend.integration;
+
+import com.backend.persistence.player.PlayerLocation;
+import com.backend.persistence.player.PlayerLocationRepository;
+import com.backend.persistence.player.PlayerProfile;
+import com.backend.persistence.player.PlayerProfileRepository;
+import com.backend.support.PostgresIntegrationTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PlayerLocationRepositoryIntegrationTest extends PostgresIntegrationTestSupport {
+
+    @Autowired
+    private PlayerProfileRepository playerProfileRepository;
+
+    @Autowired
+    private PlayerLocationRepository playerLocationRepository;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void upsertsDurablePlayerLocationWithoutCreatingMovementHotPathWrites() {
+        PlayerProfile player = playerProfileRepository.create("subject-jinx", "jinx", "Jinx");
+
+        playerLocationRepository.upsert(player.id(), "starter-zone", 1.5, -2.25);
+        playerLocationRepository.upsert(player.id(), "starter-zone", 5.0, 6.5);
+
+        Optional<PlayerLocation> stored = playerLocationRepository.findByPlayerId(player.id());
+
+        assertThat(stored).isPresent();
+        assertThat(stored.orElseThrow().playerId()).isEqualTo(player.id());
+        assertThat(stored.orElseThrow().zoneId()).isEqualTo("starter-zone");
+        assertThat(stored.orElseThrow().positionX()).isEqualTo(5.0);
+        assertThat(stored.orElseThrow().positionY()).isEqualTo(6.5);
+        assertThat(stored.orElseThrow().updatedAt()).isNotNull();
+    }
+}

--- a/src/test/java/com/backend/integration/PlayerProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/backend/integration/PlayerProfileRepositoryIntegrationTest.java
@@ -24,23 +24,29 @@ class PlayerProfileRepositoryIntegrationTest extends PostgresIntegrationTestSupp
 
     @Test
     void createsAndReadsPlayerProfilesUsingPostgres() {
-        PlayerProfile created = repository.create("riven-main", "Riven Main");
+        PlayerProfile created = repository.create("subject-riven", "riven-main", "Riven Main");
 
         Optional<PlayerProfile> byId = repository.findById(created.id());
         Optional<PlayerProfile> byHandle = repository.findByHandle(created.handle());
+        Optional<PlayerProfile> bySubject = repository.findByExternalSubject(created.externalSubject());
 
         assertThat(byId).isPresent();
         assertThat(byHandle).isPresent();
+        assertThat(bySubject).isPresent();
         assertThat(byId.orElseThrow().id()).isEqualTo(created.id());
+        assertThat(byId.orElseThrow().externalSubject()).isEqualTo(created.externalSubject());
         assertThat(byId.orElseThrow().handle()).isEqualTo(created.handle());
         assertThat(byId.orElseThrow().displayName()).isEqualTo(created.displayName());
         assertThat(byHandle.orElseThrow().id()).isEqualTo(created.id());
+        assertThat(byHandle.orElseThrow().externalSubject()).isEqualTo(created.externalSubject());
         assertThat(byHandle.orElseThrow().handle()).isEqualTo(created.handle());
         assertThat(byHandle.orElseThrow().displayName()).isEqualTo(created.displayName());
+        assertThat(bySubject.orElseThrow().id()).isEqualTo(created.id());
+        assertThat(bySubject.orElseThrow().externalSubject()).isEqualTo(created.externalSubject());
         assertThat(repository.count()).isEqualTo(1);
         assertThat(repository.findAll())
                 .singleElement()
-                .extracting(PlayerProfile::id, PlayerProfile::handle, PlayerProfile::displayName)
-                .containsExactly(created.id(), created.handle(), created.displayName());
+                .extracting(PlayerProfile::id, PlayerProfile::externalSubject, PlayerProfile::handle, PlayerProfile::displayName)
+                .containsExactly(created.id(), created.externalSubject(), created.handle(), created.displayName());
     }
 }

--- a/src/test/java/com/backend/integration/PlayerProfileRepositoryIntegrationTest.java
+++ b/src/test/java/com/backend/integration/PlayerProfileRepositoryIntegrationTest.java
@@ -10,6 +10,11 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -48,5 +53,32 @@ class PlayerProfileRepositoryIntegrationTest extends PostgresIntegrationTestSupp
                 .singleElement()
                 .extracting(PlayerProfile::id, PlayerProfile::externalSubject, PlayerProfile::handle, PlayerProfile::displayName)
                 .containsExactly(created.id(), created.externalSubject(), created.handle(), created.displayName());
+    }
+
+    @Test
+    void findsOrCreatesPlayerProfilesAtomicallyForConcurrentRequests() throws Exception {
+        long beforeCount = repository.count();
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            Callable<PlayerProfile> resolveProfile = () ->
+                    repository.findOrCreate("subject-lux", "lux-main", "Lux Main");
+
+            Future<PlayerProfile> first = executor.submit(resolveProfile);
+            Future<PlayerProfile> second = executor.submit(resolveProfile);
+
+            PlayerProfile firstProfile = get(first);
+            PlayerProfile secondProfile = get(second);
+
+            assertThat(firstProfile.id()).isEqualTo(secondProfile.id());
+            assertThat(firstProfile.externalSubject()).isEqualTo("subject-lux");
+            assertThat(secondProfile.externalSubject()).isEqualTo("subject-lux");
+        }
+
+        assertThat(repository.count()).isEqualTo(beforeCount + 1);
+        assertThat(repository.findByExternalSubject("subject-lux")).isPresent();
+    }
+
+    private PlayerProfile get(Future<PlayerProfile> future) throws ExecutionException, InterruptedException {
+        return future.get();
     }
 }

--- a/src/test/java/com/backend/support/PostgresIntegrationTestSupport.java
+++ b/src/test/java/com/backend/support/PostgresIntegrationTestSupport.java
@@ -1,11 +1,13 @@
 package com.backend.support;
 
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.annotation.DirtiesContext;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers(disabledWithoutDocker = true)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public abstract class PostgresIntegrationTestSupport {
 
     @Container


### PR DESCRIPTION
## Summary
Introduces the first gameplay session and movement slice for the backend.

- adds gameplay session issuing for authenticated players
- adds websocket gameplay transport and movement intent handling
- adds in-memory active session coordination and authoritative movement state
- adds durable player location persistence for session shutdown
- extends player identity storage with `external_subject`
- adds tests for movement, session issuance, and persistence behavior

## Review Follow-ups
- websocket cleanup now only tears down a session when the closing socket matches the attached connection id
- player profile `findOrCreate` now uses a single Postgres upsert/return path so concurrent requests for the same subject remain safe
- added regression tests for connection-aware session close behavior and concurrent profile resolution

## Verification
- `./mvnw.cmd -B "-Dtest=GameplaySessionServiceTest,GameplayWebSocketHandlerTest,PlayerProfileRepositoryIntegrationTest,GameplaySessionIntegrationTest" test`
- in this environment the Docker-backed integration tests were skipped because Testcontainers could not start without Docker